### PR TITLE
Fix conflicting types of temporary variables caused compilation errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libicd-network-wpasupplicant (0.1.14) unstable; urgency=low
+
+  * Fix conflicting types of temporary variables caused compilation errors
+
+ -- Blagovest Petrov <blagovest@petrovs.info> Tue, 29 Nov 2022 21:25:16 +0200
+
 libicd-network-wpasupplicant (0.1.13) unstable; urgency=low
 
   * Fix problem with invalid network entries

--- a/src/wpaicd.c
+++ b/src/wpaicd.c
@@ -594,9 +594,9 @@ static void on_scan_done(GDBusProxy * proxy,
     /* TODO: Ensure everything is freed, GError checking, Gerror re-initialisation, etc */
     /* TODO: Ensure that we properly deal with errors / missing values */
 
-    gchar *tmp = g_variant_print(parameters, TRUE);
-    WPALOG_DEBUG("on_scan_done. params: %s", tmp);
-    g_free(tmp);
+    gchar *tmp_param = g_variant_print(parameters, TRUE);
+    WPALOG_DEBUG("on_scan_done. params: %s", tmp_param);
+    g_free(tmp_param);
 
     GError *error = NULL;
 


### PR DESCRIPTION
The compiler was failing with this error:

```
ude/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/gconf/2 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/icd -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Werror -c wpaicd.c  -fPIC -DPIC -o .libs/wpaicd.o
wpaicd.c: In function ‘on_scan_done’:
wpaicd.c:623:15: error: conflicting types for ‘tmp’
  623 |     GVariant *tmp = g_variant_get_child_value(bsss, 0);
      |               ^~~
wpaicd.c:597:12: note: previous definition of ‘tmp’ was here
  597 |     gchar *tmp = g_variant_print(parameters, TRUE);
      |            ^~~
make[3]: *** [Makefile:461: wpaicd.lo] Error 1
make[3]: Leaving directory '/root/packages/libicd-network-wpasupplicant/src'
make[2]: *** [Makefile:532: all-recursive] Error 1
make[2]: Leaving directory '/root/packages/libicd-network-wpasupplicant'
make[1]: *** [Makefile:408: all] Error 2
make[1]: Leaving directory '/root/packages/libicd-network-wpasupplicant'
dh_auto_build: error: make -j1 returned exit code 2
make: *** [debian/rules:6: build] Error 25
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -b failed
```