### PR TITLE
wpaicd: report instantaneous signal levels

### DIFF
--- a/src/wpaicd.h
+++ b/src/wpaicd.h
@@ -101,7 +101,7 @@ typedef struct {
     gchar *ssid;
     gsize ssid_len;
 
-    gint16 signal;
+    gint32 signal;
 
     gchar *mac_addr;
     gsize mac_addr_len;


### PR DESCRIPTION
icd2 reports stale signal levels for wifi, because wpa_supplicant only updates it during an active scan. Add support for the
fi.w1.wpa_supplicant1.Interface.SignalPoll() method, which always reports up-to-date values.

Fixes: https://github.com/maemo-leste/bugtracker/issues/730